### PR TITLE
Add split subcommand while preserving legacy interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build Status](https://github.com/antifuchs/flac-tracksplit/actions/workflows/ci.yml/badge.svg) [![Docs](https://docs.rs/flac-tracksplit/badge.svg)](https://docs.rs/flac-tracksplit/) [![crates.io](https://img.shields.io/crates/v/flac-tracksplit.svg)](https://crates.io/crates/flac-tracksplit)
 
-# `flac-tracksplit` - a tool for splitting whole-disc FLAC files with embedded CUE sheets up into multiple tracks
+# `flac-tracksplit` - a tool for splitting FLAC files with embedded CUE sheets or extracting time ranges
 
 Say you were impressed by the conceptual purity of representing a *whole CD* as a single losslessly-compressed FLAC file, for archival purposes, say 11 years ago. You sunk a ton of time into ripping these CDs, dedicated a ton of storage space to them and also ensured that all the CDs you have are accurately represented as MusicBrainz releases and have perfect metadata, and all that.
 
@@ -12,9 +12,33 @@ So maybe this tool can help.
 
 `flac-tracksplit` does frame-accurate FLAC splitting along track boundaries, with a focus on *not doing unnecessary work*, and especially not re-encoding all that valuable data. It commits various crimes to get a split-out set of tracks from your archival copies, but those tracks do contain all the per-track (and whole-album) tags you have set on them, as well as decode correctly (with seeking), and they all start and end on the correct time stamps (caveat, they end on the `FRAME` boundary, which may include a few samples from the next track; this is not more than a few milliseconds in typical use though).
 
-To use it, run `flac-tracksplit --output-dir /output/files/will/go/here /path/to/your/archival/copies/*.flac`
+## Usage
+
+### Split FLAC+CUE files into tracks (original functionality)
+
+To split whole-disc FLAC files with embedded CUE sheets into individual tracks:
+
+```bash
+flac-tracksplit --output-dir /output/files/will/go/here /path/to/your/archival/copies/*.flac
+```
 
 The splitting process is multi-threaded (one archival file being processed per physical core in your machine) and should take no more than about a second per album.
+
+### Extract time ranges from FLAC files
+
+To extract a specific time range from any FLAC file:
+
+```bash
+flac-tracksplit split input.flac --from 35450 --to 44150 output.flac
+```
+
+Where:
+- `input.flac` is the source FLAC file
+- `--from 35450` specifies the start time in milliseconds
+- `--to 44150` specifies the end time in milliseconds  
+- `output.flac` is the extracted segment
+
+This performs frame-accurate extraction without re-encoding, preserving all audio quality and metadata.
 
 ## Future Work
 

--- a/flac-tracksplit/src/main.rs
+++ b/flac-tracksplit/src/main.rs
@@ -2,17 +2,22 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use bytesize::ByteSize;
-use clap::Parser;
-use flac_tracksplit::split_one_file;
+use clap::{Parser, Subcommand};
+use flac_tracksplit::{extract_sample_range, get_sample_rate, split_one_file};
 use rayon::prelude::*;
 use tracing::error;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about=None)]
+#[command(name = "flac-tracksplit", author, version, about = "Split FLAC files with embedded CUE sheets or extract time ranges", long_about = None)]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
     /// Pathnames of .flac files (with embedded CUE sheets) to split into tracks.
+    /// This is the legacy interface - if no subcommand is provided, this will be used.
+    #[arg(value_name = "FILES")]
     paths: Vec<PathBuf>,
 
     /// Output directory into which to sort resulting per-track FLAC files.
@@ -27,6 +32,26 @@ struct Args {
     /// without having to rewrite the whole file.
     #[arg(long, default_value = "2kB")]
     metadata_padding: ByteSize,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Extract a time range from a FLAC file
+    Split {
+        /// Input FLAC file
+        input: PathBuf,
+
+        /// Starting time in milliseconds
+        #[arg(long = "from", value_name = "MS")]
+        from_ms: u64,
+
+        /// Ending time in milliseconds
+        #[arg(long = "to", value_name = "MS")]
+        to_ms: u64,
+
+        /// Output FLAC file
+        output: PathBuf,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -47,25 +72,67 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
-    let base_path = args.output_dir.as_path();
-    let metadata_padding: u32 = args
-        .metadata_padding
-        .as_u64()
-        .try_into()
-        .context("--metadata-padding should fit into a 32-bit unsigned int")?;
-    if let Err(err) = args
-        .paths
-        .into_par_iter()
-        .panic_fuse()
-        .try_for_each(|path| {
-            split_one_file(&path, base_path, metadata_padding)
-                .map(|_| ())
-                .with_context(|| format!("splitting {:?}", path))
-        })
-    {
-        error!(error = %err);
-        Err(err)
-    } else {
-        Ok(())
+
+    match args.command {
+        Some(Commands::Split {
+            input,
+            from_ms,
+            to_ms,
+            output,
+        }) => {
+            // New split subcommand
+            if from_ms >= to_ms {
+                anyhow::bail!("from_ms ({}) must be less than to_ms ({})", from_ms, to_ms);
+            }
+
+            // Get sample rate to convert milliseconds to samples
+            let sample_rate = get_sample_rate(&input)
+                .with_context(|| format!("reading sample rate from {:?}", input))?;
+
+            let from_sample = (from_ms * sample_rate) / 1000;
+            let to_sample = (to_ms * sample_rate) / 1000;
+
+            extract_sample_range(&input, from_sample, to_sample, &output).with_context(|| {
+                format!(
+                    "extracting {}ms to {}ms (samples {} to {}) from {:?} to {:?}",
+                    from_ms, to_ms, from_sample, to_sample, input, output
+                )
+            })?;
+
+            println!(
+                "Successfully extracted {}ms to {}ms (samples {} to {}) from {:?} to {:?}",
+                from_ms, to_ms, from_sample, to_sample, input, output
+            );
+            Ok(())
+        }
+        None => {
+            // Legacy interface - split files with embedded CUE sheets
+            if args.paths.is_empty() {
+                eprintln!("Error: No input files provided. Use --help for usage information.");
+                std::process::exit(1);
+            }
+
+            let base_path = args.output_dir.as_path();
+            let metadata_padding: u32 = args
+                .metadata_padding
+                .as_u64()
+                .try_into()
+                .context("--metadata-padding should fit into a 32-bit unsigned int")?;
+            if let Err(err) = args
+                .paths
+                .into_par_iter()
+                .panic_fuse()
+                .try_for_each(|path| {
+                    split_one_file(&path, base_path, metadata_padding)
+                        .map(|_| ())
+                        .with_context(|| format!("splitting {:?}", path))
+                })
+            {
+                error!(error = %err);
+                Err(err)
+            } else {
+                Ok(())
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add new `split` subcommand with `--from` and `--to` options for extracting time ranges from FLAC files
- Preserve original CLI interface for backward compatibility (`flac-tracksplit --output-dir /path /files/*.flac`)
- Add `extract_sample_range` and `get_sample_rate` functions to support time-based splitting
- Update documentation to cover both interfaces

## Changes
- **New subcommand interface**: `flac-tracksplit split <input> --from <ms> --to <ms> <output>`
- **Legacy interface**: continues to work as documented in README
- **Library functions**: `extract_sample_range` and `get_sample_rate` for time-based operations
- **Improved audio handling**: Update `Track::write_audio` to handle seeking and packet skipping for arbitrary start positions
- **Documentation**: Updated README.md with usage examples for both interfaces
- **Code cleanup**: Remove unused `more_asserts` dependency

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Clippy lints pass
- [x] Legacy interface works with original arguments
- [x] New split subcommand works with `--from` and `--to` arguments
- [x] Help output shows both interfaces correctly
- [x] Documentation updated

## Backward Compatibility
The original CLI interface remains unchanged - existing scripts and workflows will continue to work exactly as before.